### PR TITLE
Formatting and linting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+# http://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{py,ini}]
+indent_style = space
+indent_size = 4
+
+[*.{html,css,scss,json,yml}]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,13 @@ url = "https://pypi.org/simple"
 verify_ssl = true
 
 [dev-packages]
+flake8 = "*"
+isort = "*"
+rope = "*"
+flake8-django = "*"
+flake8-pep3101 = "*"
+flake8-string-format = "*"
+black = "==19.3b0"
 
 [packages]
 django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "dec8042526e187a78c3a883fd384f4aa6382efa203560718d950257854d73203"
+            "sha256": "d9fbb3dda8392b57ad3174dae8bb3785af20fcad34935bd924e195d07b395f9c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -101,5 +101,118 @@
             "version": "==1.2"
         }
     },
-    "develop": {}
+    "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92",
+                "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"
+            ],
+            "version": "==1.4.3"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
+            ],
+            "version": "==19.1.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:09a9dcb7c46ed496a9850b76e4e825d6049ecd38b611f1224857a79bd985a8cf",
+                "sha256:68950ffd4d9169716bcb8719a56c07a2f4485354fec061cdd5910aa07369731c"
+            ],
+            "index": "pypi",
+            "version": "==19.3b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:2335065e6395b9e67ca716de5f7526736bfa6ceead690adf616d925bdc622b13",
+                "sha256:5b94b49521f6456670fdb30cd82a4eca9412788a93fa6dd6df72c94d5a8ff2d7"
+            ],
+            "version": "==7.0"
+        },
+        "entrypoints": {
+            "hashes": [
+                "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
+                "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"
+            ],
+            "version": "==0.3"
+        },
+        "flake8": {
+            "hashes": [
+                "sha256:859996073f341f2670741b51ec1e67a01da142831aa1fdc6242dbf88dffbe661",
+                "sha256:a796a115208f5c03b18f332f7c11729812c8c3ded6c46319c59b53efd3819da8"
+            ],
+            "index": "pypi",
+            "version": "==3.7.7"
+        },
+        "flake8-django": {
+            "hashes": [
+                "sha256:7329ec2e2b8b194e8109639c534359014c79df4d50b14f4b85b8395edc5d6760"
+            ],
+            "index": "pypi",
+            "version": "==0.0.4"
+        },
+        "flake8-pep3101": {
+            "hashes": [
+                "sha256:493821d6bdd083794eb0691ebe5b68e5c520b622b269d60e54308fb97440e21a",
+                "sha256:b661ab718df42b87743dde266ef5de4f9e900b56c67dbccd45d24cf527545553"
+            ],
+            "index": "pypi",
+            "version": "==1.2.1"
+        },
+        "flake8-string-format": {
+            "hashes": [
+                "sha256:68ea72a1a5b75e7018cae44d14f32473c798cf73d75cbaed86c6a9a907b770b2",
+                "sha256:774d56103d9242ed968897455ef49b7d6de272000cfa83de5814273a868832f1"
+            ],
+            "index": "pypi",
+            "version": "==0.2.3"
+        },
+        "isort": {
+            "hashes": [
+                "sha256:08f8e3f0f0b7249e9fad7e5c41e2113aba44969798a26452ee790c06f155d4ec",
+                "sha256:4e9e9c4bd1acd66cf6c36973f29b031ec752cbfd991c69695e4e259f9a756927"
+            ],
+            "index": "pypi",
+            "version": "==4.3.16"
+        },
+        "mccabe": {
+            "hashes": [
+                "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
+                "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"
+            ],
+            "version": "==0.6.1"
+        },
+        "pycodestyle": {
+            "hashes": [
+                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
+                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+            ],
+            "version": "==2.5.0"
+        },
+        "pyflakes": {
+            "hashes": [
+                "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0",
+                "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"
+            ],
+            "version": "==2.1.1"
+        },
+        "rope": {
+            "hashes": [
+                "sha256:6b728fdc3e98a83446c27a91fc5d56808a004f8beab7a31ab1d7224cecc7d969",
+                "sha256:c5c5a6a87f7b1a2095fb311135e2a3d1f194f5ecb96900fdd0a9100881f48aaf",
+                "sha256:f0dcf719b63200d492b85535ebe5ea9b29e0d0b8aebeb87fe03fc1a65924fdaf"
+            ],
+            "index": "pypi",
+            "version": "==0.14.0"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c",
+                "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
+            ],
+            "version": "==0.10.0"
+        }
+    }
 }

--- a/manage.py
+++ b/manage.py
@@ -2,8 +2,8 @@
 import os
 import sys
 
-if __name__ == '__main__':
-    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'preventionpoint.settings')
+if __name__ == "__main__":
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "preventionpoint.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/preventionpoint/settings.py
+++ b/preventionpoint/settings.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 # See https://docs.djangoproject.com/en/2.1/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'gz!+^ra#d*j&rpq@^udd89hwzq7%z%%!c=pgl)wac!+rcp8+d-'
+SECRET_KEY = "gz!+^ra#d*j&rpq@^udd89hwzq7%z%%!c=pgl)wac!+rcp8+d-"
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
@@ -30,60 +30,60 @@ ALLOWED_HOSTS = []
 
 # Application definition
 REST_FRAMEWORK = {
-    'DEFAULT_AUTHENTICATION_CLASSES': [
-        'rest_framework_simplejwt.authentication.JWTAuthentication',
-    ],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework_simplejwt.authentication.JWTAuthentication"
+    ]
 }
 
 INSTALLED_APPS = [
-    'django.contrib.admin',
-    'django.contrib.auth',
-    'django.contrib.contenttypes',
-    'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
-    'rest_framework',
-    'step',
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "rest_framework",
+    "step",
 ]
 
 MIDDLEWARE = [
-    'django.middleware.security.SecurityMiddleware',
-    'django.contrib.sessions.middleware.SessionMiddleware',
-    'django.middleware.common.CommonMiddleware',
-    'django.middleware.csrf.CsrfViewMiddleware',
-    'django.contrib.auth.middleware.AuthenticationMiddleware',
-    'django.contrib.messages.middleware.MessageMiddleware',
-    'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    "django.middleware.security.SecurityMiddleware",
+    "django.contrib.sessions.middleware.SessionMiddleware",
+    "django.middleware.common.CommonMiddleware",
+    "django.middleware.csrf.CsrfViewMiddleware",
+    "django.contrib.auth.middleware.AuthenticationMiddleware",
+    "django.contrib.messages.middleware.MessageMiddleware",
+    "django.middleware.clickjacking.XFrameOptionsMiddleware",
 ]
 
-ROOT_URLCONF = 'preventionpoint.urls'
+ROOT_URLCONF = "preventionpoint.urls"
 
 TEMPLATES = [
     {
-        'BACKEND': 'django.template.backends.django.DjangoTemplates',
-        'DIRS': [],
-        'APP_DIRS': True,
-        'OPTIONS': {
-            'context_processors': [
-                'django.template.context_processors.debug',
-                'django.template.context_processors.request',
-                'django.contrib.auth.context_processors.auth',
-                'django.contrib.messages.context_processors.messages',
-            ],
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [
+                "django.template.context_processors.debug",
+                "django.template.context_processors.request",
+                "django.contrib.auth.context_processors.auth",
+                "django.contrib.messages.context_processors.messages",
+            ]
         },
-    },
+    }
 ]
 
-WSGI_APPLICATION = 'preventionpoint.wsgi.application'
+WSGI_APPLICATION = "preventionpoint.wsgi.application"
 
 
 # Database
 # https://docs.djangoproject.com/en/2.1/ref/settings/#databases
 
 DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'db.sqlite3'),
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.path.join(BASE_DIR, "db.sqlite3"),
     }
 }
 
@@ -93,26 +93,20 @@ DATABASES = {
 
 AUTH_PASSWORD_VALIDATORS = [
     {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
+        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"
     },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
+    {"NAME": "django.contrib.auth.password_validation.MinimumLengthValidator"},
+    {"NAME": "django.contrib.auth.password_validation.CommonPasswordValidator"},
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
 ]
 
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.1/topics/i18n/
 
-LANGUAGE_CODE = 'en-us'
+LANGUAGE_CODE = "en-us"
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = "UTC"
 
 USE_I18N = True
 
@@ -124,4 +118,4 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.1/howto/static-files/
 
-STATIC_URL = '/static/'
+STATIC_URL = "/static/"

--- a/preventionpoint/urls.py
+++ b/preventionpoint/urls.py
@@ -20,17 +20,22 @@ from rest_framework_simplejwt import views as jwt_views
 
 from step.users import views as user_views
 from step.urine_drug_screens import views as uds_views
-router = routers.DefaultRouter()
-router.register(r'users', user_views.UserViewSet)
-router.register(r'groups', user_views.GroupViewSet)
-router.register(r'uds', uds_views.UrineDrugScreenViewSet)
 
-admin.site.site_header = 'Prevention Point Philadelphia'
+router = routers.DefaultRouter()
+router.register(r"users", user_views.UserViewSet)
+router.register(r"groups", user_views.GroupViewSet)
+router.register(r"uds", uds_views.UrineDrugScreenViewSet)
+
+admin.site.site_header = "Prevention Point Philadelphia"
 
 urlpatterns = [
-    path('api/', include(router.urls)),
-    path('api/token/', jwt_views.TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('api/token/refresh/', jwt_views.TokenRefreshView.as_view(), name='token_refresh'),
-    path('step/', include('step.urls')),
-    path('admin/', admin.site.urls),
+    path("api/", include(router.urls)),
+    path(
+        "api/token/", jwt_views.TokenObtainPairView.as_view(), name="token_obtain_pair"
+    ),
+    path(
+        "api/token/refresh/", jwt_views.TokenRefreshView.as_view(), name="token_refresh"
+    ),
+    path("step/", include("step.urls")),
+    path("admin/", admin.site.urls),
 ]

--- a/preventionpoint/wsgi.py
+++ b/preventionpoint/wsgi.py
@@ -11,6 +11,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'preventionpoint.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "preventionpoint.settings")
 
 application = get_wsgi_application()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.black]
+line-length = 88
+
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.hg
+    | \.mypy_cache
+    | \.tox
+    | _build
+    | buck-out
+    | build
+    | dist
+    | migrations
+  )/
+)
+'''

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,12 @@
+[flake8]
+ignore = E501,E303,W503
+exclude = .tox,.git,*/migrations/*,*/static/CACHE/*,docs,node_modules
+max-line-length = 88
+
+[isort]
+combine_as_imports = true
+default_section = THIRDPARTY
+include_trailing_comma = true
+known_first_party = django
+line_length = 79
+multi_line_output = 5

--- a/step/admin.py
+++ b/step/admin.py
@@ -1,5 +1,12 @@
 from django.contrib import admin
-from .models import Participant, Medication, UrineDrugScreen, CaseManagement, Appointment, Employee
+from .models import (
+    Participant,
+    Medication,
+    UrineDrugScreen,
+    CaseManagement,
+    Appointment,
+    Employee,
+)
 
 # Register your models here.
 admin.site.register(Medication)
@@ -8,27 +15,34 @@ admin.site.register(CaseManagement)
 admin.site.register(Appointment)
 admin.site.register(Employee)
 
+
 class BaseInline(admin.StackedInline):
     extra = 0
+
 
 class UrineDrugScreenInline(BaseInline):
     model = UrineDrugScreen
 
+
 class AppointmentInline(BaseInline):
     model = Appointment
+
 
 class MedicationInline(BaseInline):
     model = Medication
 
+
 class CaseManagement(BaseInline):
     model = CaseManagement
 
+
 class ParticipantAdmin(admin.ModelAdmin):
     inlines = [
-            AppointmentInline,
-            MedicationInline,
-            CaseManagement,
-            UrineDrugScreenInline,
-            ]
+        AppointmentInline,
+        MedicationInline,
+        CaseManagement,
+        UrineDrugScreenInline,
+    ]
+
 
 admin.site.register(Participant, ParticipantAdmin)

--- a/step/apps.py
+++ b/step/apps.py
@@ -2,4 +2,4 @@ from django.apps import AppConfig
 
 
 class StepConfig(AppConfig):
-    name = 'step'
+    name = "step"

--- a/step/management/commands/seed.py
+++ b/step/management/commands/seed.py
@@ -9,7 +9,8 @@ import random
 
 fake = Faker()
 
-DEFAULT_GROUPS = ['front desk', 'case manager', 'admin']
+DEFAULT_GROUPS = ["front desk", "case manager", "admin"]
+
 
 class Command(BaseCommand):
     help = "seed database for testing and development."
@@ -17,17 +18,20 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         run_seed(self)
 
+
 def run_seed(self):
-    call_command('migrate')
-    call_command('flush')
-    call_command('loaddata', 'users')
+    call_command("migrate")
+    call_command("flush")
+    call_command("loaddata", "users")
     create_groups()
     create_participants()
+
 
 def create_groups():
     for group in DEFAULT_GROUPS:
         Group.objects.get_or_create(name=group)
-        print("Created group: {}".format(group))
+        print(f"Created group: {group}")
+
 
 def create_participants():
     gender_list = list(Gender)
@@ -40,45 +44,47 @@ def create_participants():
         race = random.choice(race_list)
 
         participant = Participant(
-                first_name=fake.first_name(),
-                last_name=fake.last_name(),
-                pp_id="todo",
-                gender=gender.value,
-                race=race.value,
-                last_four_ssn=last_four,
-                date_of_birth=profile['birthdate'],
-                start_date=fake.date_time(),
-            )
+            first_name=fake.first_name(),
+            last_name=fake.last_name(),
+            pp_id="todo",
+            gender=gender.value,
+            race=race.value,
+            last_four_ssn=last_four,
+            date_of_birth=profile["birthdate"],
+            start_date=fake.date_time(),
+        )
         participant.full_clean()
         participant.save()
         create_uds_results(participant)
 
+
 def random_bool():
     return bool(random.getrandbits(1))
 
+
 def create_uds_results(participant):
-    for _ in range(random.randint(2,10)):
-        test_date = fake.date_between(start_date=participant.start_date, end_date='+5y')
+    for _ in range(random.randint(2, 10)):
+        test_date = fake.date_between(start_date=participant.start_date, end_date="+5y")
 
         uds = UrineDrugScreen(
-                participant=participant,
-                uds_temp=random.randint(85,105),
-                date_of_test=test_date,
-                pregnancy_test=random_bool(),
-                opiates=random_bool(),
-                fentanyl=random_bool(),
-                bup=random_bool(),
-                coc=random_bool(),
-                amp=random_bool(),
-                m_amp=random_bool(),
-                thc=random_bool(),
-                mtd=random_bool(),
-                pcp=random_bool(),
-                bar=random_bool(),
-                bzo=random_bool(),
-                tca=random_bool(),
-                oxy=random_bool(),
-            )
+            participant=participant,
+            uds_temp=random.randint(85, 105),
+            date_of_test=test_date,
+            pregnancy_test=random_bool(),
+            opiates=random_bool(),
+            fentanyl=random_bool(),
+            bup=random_bool(),
+            coc=random_bool(),
+            amp=random_bool(),
+            m_amp=random_bool(),
+            thc=random_bool(),
+            mtd=random_bool(),
+            pcp=random_bool(),
+            bar=random_bool(),
+            bzo=random_bool(),
+            tca=random_bool(),
+            oxy=random_bool(),
+        )
 
         uds.full_clean()
         uds.save()

--- a/step/models.py
+++ b/step/models.py
@@ -2,21 +2,24 @@ from django.db import models
 
 from enum import Enum
 
+
 class Gender(Enum):
-    MALE = 'male'
-    FEMALE = 'female'
-    MTF = 'mtf'
-    FTM = 'ftm'
-    GENDER_QUEER = 'gender queer'
-    OTHER = 'other'
+    MALE = "male"
+    FEMALE = "female"
+    MTF = "mtf"
+    FTM = "ftm"
+    GENDER_QUEER = "gender queer"
+    OTHER = "other"
+
 
 class Race(Enum):
-    BLACK_AFRICAN_AMERICAN = 'black (african american)'
-    CAUCASIAN = 'white (caucasian)'
-    ASIAN_PI = 'asian pi'
-    NATIVE_AMERICAN = 'native american'
-    LATINO = 'latino'
-    OTHER = 'other'
+    BLACK_AFRICAN_AMERICAN = "black (african american)"
+    CAUCASIAN = "white (caucasian)"
+    ASIAN_PI = "asian pi"
+    NATIVE_AMERICAN = "native american"
+    LATINO = "latino"
+    OTHER = "other"
+
 
 class Participant(models.Model):
     GENDER_CHOICES = [(key.value, key.value.title()) for key in Gender]
@@ -32,13 +35,15 @@ class Participant(models.Model):
     start_date = models.DateField()
 
     def __str__(self):
-        return '%s %s' % (self.first_name, self.last_name)
+        return f"{self.first_name} {self.last_name}"
+
 
 class Medication(models.Model):
     participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
     medical_delivery = models.CharField(max_length=100)
     medication_name = models.CharField(max_length=100)
     ingestion_frequency = models.IntegerField()
+
 
 class UrineDrugScreen(models.Model):
     participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
@@ -50,43 +55,48 @@ class UrineDrugScreen(models.Model):
     fentanyl = models.BooleanField(default=False)
     bup = models.BooleanField(default=False, verbose_name="Buprenorphine")
     coc = models.BooleanField(default=False, verbose_name="Cocaine")
-    amp = models.BooleanField(default=False, verbose_name = "Amphetamine")
-    m_amp = models.BooleanField(default=False, verbose_name = "Methamphetamine")
-    thc = models.BooleanField(default=False, verbose_name = "THC")
-    mtd = models.BooleanField(default=False, verbose_name = "Methadone")
-    pcp = models.BooleanField(default=False, verbose_name = "PCP")
-    bar = models.BooleanField(default=False, verbose_name = "Barbiturates")
-    bzo = models.BooleanField(default=False, verbose_name = "Benzodiazepines")
-    tca = models.BooleanField(default=False, verbose_name = "Tricyclic Antidepressants")
-    oxy = models.BooleanField(default=False, verbose_name = "Oxycodone")
+    amp = models.BooleanField(default=False, verbose_name="Amphetamine")
+    m_amp = models.BooleanField(default=False, verbose_name="Methamphetamine")
+    thc = models.BooleanField(default=False, verbose_name="THC")
+    mtd = models.BooleanField(default=False, verbose_name="Methadone")
+    pcp = models.BooleanField(default=False, verbose_name="PCP")
+    bar = models.BooleanField(default=False, verbose_name="Barbiturates")
+    bzo = models.BooleanField(default=False, verbose_name="Benzodiazepines")
+    tca = models.BooleanField(default=False, verbose_name="Tricyclic Antidepressants")
+    oxy = models.BooleanField(default=False, verbose_name="Oxycodone")
 
     def __str__(self):
-        return 'UDS #%i for Participant #%i' % (self.id, self.participant_id)
+        return f"UDS {self.id} for Participant {self.participant_id}"
+
 
 class EmployeeRole(models.Model):
     role_value = models.CharField(max_length=30)
 
+
 # TODO: seed with front desk, case manager, admin
+
 
 class Employee(models.Model):
     fist_name = models.CharField(max_length=50)
     last_name = models.CharField(max_length=100)
     role = models.ForeignKey(EmployeeRole, on_delete=models.CASCADE)
 
+
 class CaseManagement(models.Model):
     participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
     crs_seen = models.BooleanField(default=False)
+
 
 class Appointment(models.Model):
     participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
 
     cm_employee = models.ForeignKey(
-            Employee, related_name='cm_%(class)s', on_delete=models.CASCADE
-            )
+        Employee, related_name="cm_%(class)s", on_delete=models.CASCADE
+    )
 
     crs_employee = models.ForeignKey(
-            Employee, related_name='crs_%(class)s', on_delete=models.CASCADE
-            )
+        Employee, related_name="crs_%(class)s", on_delete=models.CASCADE
+    )
 
     appointment_timestamp = models.DateTimeField()
     crs_timestamp = models.DateTimeField()
@@ -95,13 +105,16 @@ class Appointment(models.Model):
     cm_seen = models.BooleanField(default=False)
     hcv_status = models.BooleanField(default=False)
 
+
 # TODO: we probably want to move the HCV data into its own table(s), similar to how UDS works
+
 
 class BehavioralHealthNotes(models.Model):
     participant = models.ForeignKey(Participant, on_delete=models.CASCADE)
     employee = models.ForeignKey(Employee, on_delete=models.CASCADE)
     note_timestamp = models.DateTimeField()
     behavior_note = models.TextField()
+
 
 class HCVNotes(models.Model):
     participant = models.ForeignKey(Appointment, on_delete=models.CASCADE)

--- a/step/urine_drug_screens/serializers.py
+++ b/step/urine_drug_screens/serializers.py
@@ -1,7 +1,25 @@
 from step.models import UrineDrugScreen
 from rest_framework import serializers
 
+
 class UrineDrugScreenSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = UrineDrugScreen
-        fields = ('date_of_test', 'uds_temp', 'pregnancy_test', 'opiates', 'fentanyl', 'bup', 'coc', 'amp', 'm_amp', 'thc', 'mtd', 'pcp', 'bar', 'bzo', 'tca', 'oxy')
+        fields = (
+            "date_of_test",
+            "uds_temp",
+            "pregnancy_test",
+            "opiates",
+            "fentanyl",
+            "bup",
+            "coc",
+            "amp",
+            "m_amp",
+            "thc",
+            "mtd",
+            "pcp",
+            "bar",
+            "bzo",
+            "tca",
+            "oxy",
+        )

--- a/step/urine_drug_screens/views.py
+++ b/step/urine_drug_screens/views.py
@@ -2,9 +2,11 @@ from rest_framework import viewsets
 from step.models import UrineDrugScreen
 from step.urine_drug_screens.serializers import UrineDrugScreenSerializer
 
+
 class UrineDrugScreenViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows UDS to be viewed or edited
     """
+
     queryset = UrineDrugScreen.objects.all()
     serializer_class = UrineDrugScreenSerializer

--- a/step/urls.py
+++ b/step/urls.py
@@ -3,6 +3,6 @@ from django.urls import path
 from . import views
 
 urlpatterns = [
-    path('', views.index, name='index'),
-    path('hello/', views.HelloView.as_view(), name='hello'),
+    path("", views.index, name="index"),
+    path("hello/", views.HelloView.as_view(), name="hello"),
 ]

--- a/step/users/serializers.py
+++ b/step/users/serializers.py
@@ -5,9 +5,10 @@ from rest_framework import serializers
 class UserSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = User
-        fields = ('url', 'username', 'email', 'groups')
+        fields = ("url", "username", "email", "groups")
+
 
 class GroupSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = Group
-        fields = ('url', 'name')
+        fields = ("url", "name")

--- a/step/users/views.py
+++ b/step/users/views.py
@@ -7,7 +7,8 @@ class UserViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows users to be viewed or edited.
     """
-    queryset = User.objects.all().order_by('-date_joined')
+
+    queryset = User.objects.all().order_by("-date_joined")
     serializer_class = UserSerializer
 
 
@@ -15,5 +16,6 @@ class GroupViewSet(viewsets.ModelViewSet):
     """
     API endpoint that allows groups to be viewed or edited.
     """
+
     queryset = Group.objects.all()
     serializer_class = GroupSerializer

--- a/step/views.py
+++ b/step/views.py
@@ -7,9 +7,10 @@ from rest_framework.permissions import IsAuthenticated
 def index(request):
     return HttpResponse("Hello, Prevention Point.")
 
+
 class HelloView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def get(self, request):
-        content = {'message', 'Hello, Prevention Point (from rest framework)'}
+        content = {"message", "Hello, Prevention Point (from rest framework)"}
         return Response(content)


### PR DESCRIPTION
Installed packages to encourage uniform style conventions:
- linting: [`flake8`](http://flake8.pycqa.org/en/latest/index.html#)
  - `flake8` options found in `setup.cfg`
   - `flake8` plugins:
     - `flake8-django`: Django specific linting errors
     - `flake8-pep3101`: discourages modulo string substitution
     - `flake8-string-format`: linting for .format() or f strings
- formatting: 
   - [`black`](https://black.readthedocs.io/en/stable/)
      - settings found in `pyproject.toml`
   - `.editorconfig` is a config file for, well,  [editorconfig](https://editorconfig.org/). Install it as a plugin for your [editor of choice](https://editorconfig.org/#download)

Ran black and auto-formatted as much as it could, then made a few more changes based on flake8 suggestions.

Things that flake8 is still catching that I've left unresolved:
 - `DJ08 __str__ method should be present in all db models`. I'm going to leave this to whomever wrote those models to implement `__str__` methods that make sense. 
 - a few unused imports, but they may end up being used in the future





