### PR TITLE
Make fake visits and front desk events all today, leave some FDE's st…

### DIFF
--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -1,5 +1,5 @@
-import random, pytz
-
+import random
+from django.utils import timezone
 from django.core.management.base import BaseCommand
 from django.core.management import call_command
 from django.contrib.auth.models import Group, User
@@ -16,7 +16,7 @@ fake = Faker()
 DEFAULT_DEV_ENV_PASS = 'password123'
 DEFAULT_GROUPS = [FRONT_DESK, CASE_MANAGER, ADMIN]
 DEFAULT_NUMBER_PARTICIPANTS = 10
-DEFAULT_NUMBER_VISITS = 20
+DEFAULT_NUMBER_VISITS = 100
 
 #Cribbed from prevpoint-backend 2 July 2019 Marieke
 DEFAULT_PROGRAMS = {
@@ -191,14 +191,14 @@ def create_programs(output=True):
               print("Created {}: '{}'". format(p.name, s.name))
 
 def create_visits(output=True):
-    '''Create fake visits and front desk events, depending on Participants and Programs.  Uses UTC in created_at date_times'''
+    '''Create fake visits and front desk events, depending on Participants and Programs. Visits are created using now(), i.e. today'''
     participants = Participant.objects.all()
     programs = Program.objects.all()
 
     for _ in range(DEFAULT_NUMBER_VISITS):
         v = Visit()
         v.participant = random.choice(participants)
-        v.created_at = pytz.utc.localize(fake.date_time())
+        v.created_at = timezone.now()
         v.program = random.choice(programs)
         v.notes = fake.sentence(nb_words=10, variable_nb_words=True, ext_word_list=None)
         v.full_clean()
@@ -211,7 +211,7 @@ def create_visits(output=True):
             print("Created visit: {} {}, {}, {}, {}". format(v.participant.first_name, v.participant.last_name, v.created_at, v.program.name, v.notes))
 
 def create_event(visit, type):
-    '''Create a FrontDeskEvent for thie visit and of this type, e.g. ARRIVED, STEPPED_OUT'''
+    '''Create a FrontDeskEvent for thie visit and of this type, e.g. ARRIVED, STEPPED_OUT. Events are created now(), i.e. today'''
     f = FrontDeskEvent()
     f.visit = visit
     f.event_type = type
@@ -219,9 +219,9 @@ def create_event(visit, type):
     f.save()
 
 def arrived(visit):
-    '''After ARRIVED, can be either LEFT, SEEN or STEPPED_OUT'''
+    '''After ARRIVED, can be either LEFT, SEEN, STEPPED_OUT or pending (still in ARRIVED status)'''
     create_event(visit, "ARRIVED")
-    random.choice([left, seen, stepped_out])(visit)
+    random.choice([left, seen, stepped_out, pending])(visit)
 
 def left(visit):
     create_event(visit, "LEFT")
@@ -230,12 +230,14 @@ def seen(visit):
     create_event(visit, "SEEN")
 
 def stepped_out(visit):
-    '''After STEPPED_OUT can be either LEFT or CAME_BACK'''
+    '''After STEPPED_OUT can be either LEFT, CAME_BACK or pending (still in STEPPED_OUT status)'''
     create_event(visit, "STEPPED_OUT")
-    random.choice([left, came_back])(visit)
+    random.choice([left, came_back, pending])(visit)
 
 def came_back(visit):
-    '''After CAME_BACK, either LEFT or SEEN'''
+    '''After CAME_BACK, either LEFT, SEEN or pending (still in CAME_BACK status)'''
     create_event(visit, "CAME_BACK")
-    random.choice([left, seen])(visit)
+    random.choice([left, seen, pending])(visit)
 
+def pending(visit):
+    pass


### PR DESCRIPTION
…ill pending, (ARRIVED, CAME_BACK state), increase default # of visits

I changed the fake-date seed.py so the front desk events would be visible in the queues. There are only 3 real changes:  Make the Visits and FDE's created_at using now(), change the random network that makes the FDE's so that some visits are in a pending state, (ie ARRIVED or CAME_BACK), and increase the number of visits so each Program has something in the queue