### PR TITLE
Fix console warnings from NotesDialog proptypes

### DIFF
--- a/frontend/src/components/NotesDialog.js
+++ b/frontend/src/components/NotesDialog.js
@@ -55,8 +55,8 @@ function NotesDialog({ visibleDialog, toggleVisibleDialog }) {
 }
 
 NotesDialog.propTypes = {
-  visibleDialog: PropTypes.boolean,
-  toggleVisibleDialog: PropTypes.function,
+  visibleDialog: PropTypes.bool,
+  toggleVisibleDialog: PropTypes.func,
 }
 
 export default NotesDialog


### PR DESCRIPTION
Fixes the following browser console warning introduced in https://github.com/CodeForPhilly/prevention-point/pull/139

```javascript
Warning: Failed prop type: NotesDialog: prop type `toggleVisibleDialog` is invalid; it must be a function, usually from the `prop-types` package, but received `undefined`.
```