### PR TITLE
Program availability toydata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ Temporary Items
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
+.mypy_cache/
 
 # C extensions
 *.so

--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -111,8 +111,8 @@ class AvailabilityWindowProvider(BaseProvider):
 
     def availability_window(self, start_hour = 10, end_hour = 17):
         """Returns a tuple (start_time, end_time)"""
-        window_begin = random.randint(start_hour, end_hour - 1)
-        end_hour = random.randint(window_begin, end_hour)
+        window_begin = random.randint(start_hour, end_hour - 2)
+        end_hour = random.randint(window_begin + 1, end_hour)
         return datetime.time(hour=window_begin), datetime.time(hour=end_hour)
        
 

--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -111,9 +111,9 @@ class AvailabilityWindowProvider(BaseProvider):
 
     def availability_window(self, start_hour = 10, end_hour = 17):
         """Returns a tuple (start_time, end_time)"""
-        start_hour = random.randint(start_hour, end_hour)
-        end_hour = random.randint(start_hour, end_hour)
-        return datetime.time(hour=start_hour), datetime.time(hour=end_hour)
+        window_begin = random.randint(start_hour, end_hour - 1)
+        end_hour = random.randint(window_begin, end_hour)
+        return datetime.time(hour=window_begin), datetime.time(hour=end_hour)
        
 
 fake.add_provider(AvailabilityWindowProvider)

--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -109,12 +109,11 @@ class AvailabilityWindowProvider(BaseProvider):
     __provider__ = "availability window"
     __lang__ = "en_US"
 
-    def availability_window(self):
+    def availability_window(self, start_hour = 10, end_hour = 17):
         """Returns a tuple (start_time, end_time)"""
-        END_HOUR = 16  # 4pm
-        start_hour = random.randint(10, END_HOUR)
-        end_hour = random.randint(start_hour, END_HOUR)
-        return datetime.time(start_hour, random.randint(0, 59)), datetime.time(end_hour, random.randint(0, 59))
+        start_hour = random.randint(start_hour, end_hour)
+        end_hour = random.randint(start_hour, end_hour)
+        return datetime.time(hour=start_hour), datetime.time(hour=end_hour)
        
 
 fake.add_provider(AvailabilityWindowProvider)
@@ -330,12 +329,13 @@ def create_event(visit, type):
 
 
 def create_program_availability(output=True):
+    """create program availability"""
     programs = Program.objects.all()
     for _ in range(DEFAULT_NUMBER_PROGRAM_AVAILABILITIES):
         availability = ProgramAvailability()
         availability.program = random.choice(programs)
-        availability.day_of_week = fake.mon_fri()[0]
-        availability.start_time, availability.end_time = fake.availability_window()
+        availability.day_of_week = fake.day_of_week()
+        availability.start_time, availability.end_time = fake.availability_window(start_hour=8, end_hour=23)
         availability.full_clean()
         availability.save()
 

--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -33,7 +33,6 @@ DEFAULT_GROUPS = [FRONT_DESK, CASE_MANAGER, ADMIN]
 DEFAULT_NUMBER_PARTICIPANTS = 1000
 DEFAULT_NUMBER_VISITS = 100
 DEFAULT_NUMBER_INSURERS = 10
-DEFAULT_NUMBER_PROGRAM_AVAILABILITIES = 10
 
 # Cribbed from prevpoint-backend 2 July 2019 Marieke
 DEFAULT_PROGRAMS = {
@@ -352,25 +351,9 @@ def create_program_availability(output=True):
                     availability_two.full_clean()
                     availability_two.save()
 
-                    if output:
-                        print(
-                            "Created program availability: {} {} {} {}".format(
-                                availability_two.program,
-                                availability_two.day_of_week,
-                                availability_two.start_time,
-                                availability_two.end_time
-                            )
-                        )
-
-                if output:
-                    print(
-                        "Created program availability: {} {} {} {}".format(
-                            availability.program,
-                            availability.day_of_week,
-                            availability.start_time,
-                            availability.end_time
-                        )
-                    )
+    if output:
+        for availability in ProgramAvailability.objects.all().order_by('program'): 
+            print(f"Created program availability: {availability.program.name} {availability.day_of_week} {availability.start_time} {availability.end_time}")
 
 
 def arrived(visit):

--- a/core/management/commands/seed.py
+++ b/core/management/commands/seed.py
@@ -331,23 +331,46 @@ def create_event(visit, type):
 def create_program_availability(output=True):
     """create program availability"""
     programs = Program.objects.all()
-    for _ in range(DEFAULT_NUMBER_PROGRAM_AVAILABILITIES):
-        availability = ProgramAvailability()
-        availability.program = random.choice(programs)
-        availability.day_of_week = fake.day_of_week()
-        availability.start_time, availability.end_time = fake.availability_window(start_hour=8, end_hour=23)
-        availability.full_clean()
-        availability.save()
+    days_of_week = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+    for program in programs:
+        for day in days_of_week:
+            if random.randint(0, 10) < 8:
+                availability = ProgramAvailability()
+                availability.program = program
+                availability.day_of_week = day
+                availability.start_time, availability.end_time = fake.availability_window(
+                    start_hour=8, end_hour=18)
+                window_one_end = availability.end_time.hour
+                availability.full_clean()
+                availability.save()
+                if window_one_end < 15:
+                    availability_two = ProgramAvailability()
+                    availability_two.program = program
+                    availability_two.day_of_week = day
+                    availability_two.start_time, availability_two.end_time = fake.availability_window(
+                        start_hour=window_one_end+1, end_hour=23)
+                    availability_two.full_clean()
+                    availability_two.save()
 
-        if output:
-            print(
-                "Created program availability: {} {} {} {}".format(
-                    availability.program,
-                    availability.day_of_week,
-                    availability.start_time,
-                    availability.end_time
-                )
-            )
+                    if output:
+                        print(
+                            "Created program availability: {} {} {} {}".format(
+                                availability_two.program,
+                                availability_two.day_of_week,
+                                availability_two.start_time,
+                                availability_two.end_time
+                            )
+                        )
+
+                if output:
+                    print(
+                        "Created program availability: {} {} {} {}".format(
+                            availability.program,
+                            availability.day_of_week,
+                            availability.start_time,
+                            availability.end_time
+                        )
+                    )
 
 
 def arrived(visit):


### PR DESCRIPTION
- generates fake data for the table `core_programavailability` / `models.ProgramAvailability` 

small things: 
- my ide generated `.mypy_cache/` so i `.gitignore`'d it. 
- the faker provider `MonFri` isn't used in the last commit, but I left it in there because it might come in handy later. 
- I tried to have the same opinions as the rest of the document, one difference is I avoided one-letter var names. 