### PR TITLE
fix: prevent default form submission

### DIFF
--- a/frontend/src/components/LoginForm.js
+++ b/frontend/src/components/LoginForm.js
@@ -21,7 +21,8 @@ const LoginForm = observer(({ location }) => {
 
   const changePassword = e => setPassword(e.target.value)
 
-  const login = () => {
+  const login = event => {
+    event.preventDefault()
     rootStore.authStore.login(username, password)
   }
 


### PR DESCRIPTION
Login was broken in 422e19abdc88997d2ad85dd23dff798162ec09de -- the javascript handler didn't cancel the default form submission so the page would make a get request with the credentials in the URL before the JS could finish