### PR TITLE
Demo deploy

### DIFF
--- a/core/settings/common.py
+++ b/core/settings/common.py
@@ -25,7 +25,7 @@ SECRET_KEY = 'gz!+^ra#d*j&rpq@^udd89hwzq7%z%%!c=pgl)wac!+rcp8+d-'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
-ALLOWED_HOSTS = []
+ALLOWED_HOSTS = ['*']
 
 
 # Application definition

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       - data:/var/lib/postgresql/data/
   app:
     build: .
-    ports:
-      - "8000:8000"
+    expose:
+      - "8000"
     depends_on:
       - db
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - "8080:80"
     depends_on:
       - app
-    volumes:
-      - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+#   volumes:
+#     - ./frontend/nginx.conf:/etc/nginx/conf.d/default.conf:ro
 volumes:
   data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,4 +4,5 @@ COPY ./ /app
 RUN yarn && yarn build
 
 FROM nginx:alpine
+ADD ./nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=0 /app/dist /usr/share/nginx/html

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -18,8 +18,8 @@ server {
         proxy_pass         http://docker-app;
         proxy_redirect     off;
         proxy_set_header   Host $host;
-        proxy_set_header   X-Real-IP $remote_addr;
-        proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header   X-Forwarded-Host $server_name;
+        #proxy_set_header   X-Real-IP $remote_addr;
+        #proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        #proxy_set_header   X-Forwarded-Host $server_name;
     }
 }


### PR DESCRIPTION
This PR allows the app to run on hosts that are not localhost. There were two main issues: Django is not set to accept any hosts, and in prod it's both accessible via nginx (good) and a port straight to the app server (bad? probably not a big issue).

Changes:

* set django `ALLOW_HOSTS = ['*']`, remove host-exposed backend port.
* comment out dev settings in docker-compose.yml (eg nginx config bind mount; exposing backend port on host since it is accessed via nginx)

Note: I also commented out parts of nginx while trying to figure out how to get non localhost hosts working. Could likely uncomment again!

```
        #proxy_set_header   X-Real-IP $remote_addr;
        #proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
        #proxy_set_header   X-Forwarded-Host $server_name;
```