### PR TITLE
PR269: wrapping MUI input with PrevPoint Comp

### DIFF
--- a/frontend/src/components/ParticipantInfo.js
+++ b/frontend/src/components/ParticipantInfo.js
@@ -12,7 +12,6 @@ import "../scss/participant-search.scss"
 import FormGroup from "@material-ui/core/FormGroup"
 import FormControl from "@material-ui/core/FormControl"
 import InputLabel from "@material-ui/core/InputLabel"
-import Input from "@material-ui/core/Input"
 import Typography from "@material-ui/core/Typography"
 import Grid from "@material-ui/core/Grid"
 import TextField from "@material-ui/core/TextField"
@@ -28,6 +27,7 @@ import Button from "@material-ui/core/Button"
 import { observer } from "mobx-react-lite"
 import { useHistory } from "react-router-dom"
 import { autorun, toJS } from "mobx"
+import PrevPointInput from "./PrevPointInput"
 
 const useStyles = makeStyles(theme => ({
   paper: {
@@ -154,6 +154,11 @@ const ParticipantInfo = observer(() => {
     participantStore.setServiceList(serviceListing.services)
   }
 
+  const setPPIdAndSSN = e => {
+    participantStore.setPPId(e.target.value)
+    participantStore.setLastFourSSN(+e.target.value.substr(2))
+  }
+
   const classes = useStyles()
   return (
     <div
@@ -177,28 +182,28 @@ const ParticipantInfo = observer(() => {
                 <Grid item xs>
                   <FormControl className={classes.formControl}>
                     <InputLabel htmlFor="user_id">First name</InputLabel>
-                    <Input
+                    <PrevPointInput
                       id="user_first-name"
                       name="user_first-name"
                       value={existingParticipant.first_name}
                       onChange={e =>
                         participantStore.setFirstName(e.target.value)
                       }
-                      required
+                      required={true}
                     />
                   </FormControl>
                 </Grid>
                 <Grid item xs>
                   <FormControl className={classes.formControl}>
                     <InputLabel htmlFor="user_id">Last name</InputLabel>
-                    <Input
+                    <PrevPointInput
                       id="user_last-name"
                       name="user_last-name"
                       value={existingParticipant.last_name}
                       onChange={e =>
                         participantStore.setLastName(e.target.value)
                       }
-                      required
+                      required={true}
                     />
                   </FormControl>
                 </Grid>
@@ -229,17 +234,12 @@ const ParticipantInfo = observer(() => {
                     style={{ marginTop: 32 }}
                   >
                     <InputLabel htmlFor="user_id">UUID</InputLabel>
-                    <Input
+                    <PrevPointInput
                       id="uuid"
                       name="uuid"
                       value={existingParticipant.pp_id}
-                      onChange={e => {
-                        participantStore.setPPId(e.target.value)
-                        participantStore.setLastFourSSN(
-                          +e.target.value.substr(2)
-                        )
-                      }}
-                      required
+                      onChange={e => setPPIdAndSSN(e)}
+                      required={true}
                     />
                   </FormControl>
                 </Grid>

--- a/frontend/src/components/PrevPointInput.js
+++ b/frontend/src/components/PrevPointInput.js
@@ -1,0 +1,23 @@
+// TODO:
+/**
+ * 1. Breakup into participant and visit child components
+ * 2. Break fields into smaller individual components for re-use in other forms
+ * 3. Break up state in MobX for field re-use
+ */
+
+/* eslint-disable indent */
+import React from "react"
+import PropTypes from "prop-types"
+import Input from "@material-ui/core/Input"
+
+const PrevPointInput = props => <Input {...props} />
+
+PrevPointInput.propTypes = {
+  id: PropTypes.string,
+  name: PropTypes.string,
+  value: PropTypes.any,
+  onChange: PropTypes.func,
+  required: PropTypes.bool,
+}
+
+export default PrevPointInput

--- a/frontend/src/stores/ParticipantStore.js
+++ b/frontend/src/stores/ParticipantStore.js
@@ -121,7 +121,7 @@ export class ParticipantStore {
     this.participant.pp_id = data
   }
   @action setLastFourSSN = data => {
-    this.participant.last_four_ssn = data
+    this.participant.last_four_ssn = data.substr(2)
   }
   @action setRace = data => {
     this.participant.race = data


### PR DESCRIPTION
This PR wraps the MUI input component in a PrevPointInput wrapper that manages props with:

id,
name,
val,
changeFunc
changeFunc2

This allows only 1 import from MUI and help performance not to mention allows more modular and custom use of these components.