### PR TITLE
Fix buttonbase warning

### DIFF
--- a/frontend/src/components/QueueComponent/QueueTab/QueueTab.js
+++ b/frontend/src/components/QueueComponent/QueueTab/QueueTab.js
@@ -4,9 +4,10 @@ import QueueTabContent from "./../QueueTabContent/QueueTabContent"
 
 const QueueTab = props => (
   <Tab
+    {...props}
+    disableRipple
     component={QueueTabContent}
     onClick={e => e.preventDefault()}
-    {...props}
   />
 )
 

--- a/frontend/src/components/QueueComponent/QueueTabContent/QueueTabContent.js
+++ b/frontend/src/components/QueueComponent/QueueTabContent/QueueTabContent.js
@@ -33,7 +33,7 @@ const QueueTabContent = React.forwardRef(
     const classes = useStyles()
 
     return (
-      <Button onClick={onClick} className={classes.queueTab}>
+      <Button onClick={onClick} className={classes.queueTab} ref={_ref}>
         <div>
           <Typography className={classes.heading}>{name}</Typography>
           <div className={classes.queueTabContent}>


### PR DESCRIPTION
Fix warnings coming from buttonbase tab due to not displaying children. 

https://github.com/mui-org/material-ui/blob/master/packages/material-ui/src/ButtonBase/ButtonBase.js#L289-L303

  ```
const enableTouchRipple = mountedState && !disableRipple && !disabled;


  if (process.env.NODE_ENV !== 'production') {
    // eslint-disable-next-line react-hooks/rules-of-hooks
    React.useEffect(() => {
      if (enableTouchRipple && !rippleRef.current) {
        console.error(
          [
            'Material-UI: The `component` prop provided to ButtonBase is invalid.',
            'Please make sure the children prop is rendered in this custom component.',
          ].join('\n'),
        );
      }
    }, [enableTouchRipple]);
  }
```