### PR TITLE
Speed up the AllQueue page and requsts to queues

### DIFF
--- a/core/queue/views.py
+++ b/core/queue/views.py
@@ -40,14 +40,13 @@ class QueueViewSet(viewsets.ViewSet):
 
         front_desk_events = FrontDeskEvent.objects.select_related("visit").filter(
             visit__in=[dict(x)["id"] for x in todays_visit_data]
-        ).values("id", "visit", "event_type", "created_at")
+        ).order_by("-created_at").values("id", "visit", "event_type", "created_at")
 
         # for each visit, get the most recent front desk event, to glean current visit status
         for visit in todays_visit_data:
             events = list(
                 filter(lambda x: x.get("visit") is visit.get("id"), front_desk_events)
             )
-            events.sort(key=lambda x: x.get("created_at"), reverse=True)
             event = events[0]
 
             event_type = event.get("event_type")
@@ -62,4 +61,5 @@ class QueueViewSet(viewsets.ViewSet):
                 # then add it to the 'active visits queue'
                 active_visits_queue.append(visit)
 
+        print(len(active_visits_queue))
         return Response(active_visits_queue)

--- a/core/queue/views.py
+++ b/core/queue/views.py
@@ -47,19 +47,18 @@ class QueueViewSet(viewsets.ViewSet):
             events = list(
                 filter(lambda x: x.get("visit") is visit.get("id"), front_desk_events)
             )
-            event = events[0]
+            if events:
+                event = events[0]
+                event_type = event.get("event_type")
 
-            event_type = event.get("event_type")
+                if event_type in [
+                    FrontDeskEventType.ARRIVED.name,
+                    FrontDeskEventType.STEPPED_OUT.name,
+                    FrontDeskEventType.CAME_BACK.name,
+                ]:
+                    # if most recent front desk event is an 'active' status add it to visit object
+                    visit["status"] = event
+                    # then add it to the 'active visits queue'
+                    active_visits_queue.append(visit)
 
-            if event_type in [
-                FrontDeskEventType.ARRIVED.name,
-                FrontDeskEventType.STEPPED_OUT.name,
-                FrontDeskEventType.CAME_BACK.name,
-            ]:
-                # if most recent front desk event is an 'active' status add it to visit object
-                visit["status"] = event
-                # then add it to the 'active visits queue'
-                active_visits_queue.append(visit)
-
-        print(len(active_visits_queue))
         return Response(active_visits_queue)

--- a/core/visits/serializer.py
+++ b/core/visits/serializer.py
@@ -44,8 +44,7 @@ class VisitWithPopulationSerializer(serializers.ModelSerializer):
         representation = super().to_representation(obj)
         try:
             profile_representation = representation.pop("program_service_map")
-            for key in profile_representation:
-                representation[key] = profile_representation[key]
+            representation.update(profile_representation)
             return representation
         except TypeError:
             # TODO the program_service_map FK needs to be required, but right now is not, hence this exception


### PR DESCRIPTION
Tried to work around some of the slowness of the ModelSerializer and also consolidate some of the database trips. Biggest improvements were loading the related entities and not performing the front desk events query in a loop and also moving it to use `.values(...)` and skipping the serializer altogether. Yields some decent improvements locally. 
Before:
![master](https://user-images.githubusercontent.com/204267/81523256-53599000-931b-11ea-8f30-0a713b4a87c8.png)
After:
![performance](https://user-images.githubusercontent.com/204267/81523261-56548080-931b-11ea-9159-6360a7a5796d.png)

