### PR TITLE
Switch to cookie for JWT tokens

### DIFF
--- a/frontend/src/api/authEndpoints.js
+++ b/frontend/src/api/authEndpoints.js
@@ -1,14 +1,16 @@
+import cookieValue, { setAuthCookie } from "./cookies"
+
 export const createToken = api => async (username, password) => {
   const response = await api.post("/token/", { username, password })
   if (response.ok) {
-    localStorage.setItem("JWT_ACCESS", response.data.access)
-    localStorage.setItem("JWT_REFRESH", response.data.refresh)
+    setAuthCookie("JWT_ACCESS", response.data.access)
+    setAuthCookie("JWT_REFRESH", response.data.refresh)
   }
   return response
 }
 
 export const verifyToken = api => async () => {
-  const accessToken = localStorage.getItem("JWT_ACCESS")
+  const accessToken = cookieValue("JWT_ACCESS")
   const response = await api.post("/token/verify/", { token: accessToken })
   return response
 }

--- a/frontend/src/api/cookies.js
+++ b/frontend/src/api/cookies.js
@@ -1,0 +1,19 @@
+/**
+ * Naive get cookie value implementation
+ */
+const cookieValue = key => {
+  try {
+    return document.cookie
+      .split("; ")
+      .find(row => row.startsWith(key))
+      .split("=")[1]
+  } catch {
+    return ""
+  }
+}
+
+export const setAuthCookie = (key, value) => {
+  document.cookie = `${key}=${value}; SameSite=Strict`
+}
+
+export default cookieValue

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -17,6 +17,7 @@ import {
 } from "./visitEndpoints"
 import { getInsurers } from "./insurersEndpoints"
 import { getPrograms, getProgram, patchProgram } from "./programEndpoints"
+import cookieValue from "./cookies"
 
 const create = () => {
   const api = apisauce.create({
@@ -27,7 +28,7 @@ const create = () => {
 
   api.addRequestTransform(request => {
     if (!["/token/", "/token/verify/"].includes(request.url)) {
-      const jwtAccess = localStorage.getItem("JWT_ACCESS")
+      const jwtAccess = cookieValue("JWT_ACCESS")
       if (jwtAccess) {
         request.headers.Authorization = `Bearer ${jwtAccess}`
       }

--- a/frontend/src/api/refreshAuthLogic.js
+++ b/frontend/src/api/refreshAuthLogic.js
@@ -1,9 +1,11 @@
+import cookieValue, { setAuthCookie } from "./cookies"
+
 const refreshAuthLogic = api => async failedRequest => {
-  const refreshToken = localStorage.getItem("JWT_REFRESH")
+  const refreshToken = cookieValue("JWT_REFRESH")
   const tokenRefreshResponse = await api.post("/token/refresh/", {
     refresh: refreshToken,
   })
-  localStorage.setItem("JWT_ACCESS", tokenRefreshResponse.data.access)
+  setAuthCookie("JWT_ACCESS", tokenRefreshResponse.data.access)
   failedRequest.response.config.baseURL = ""
 
   // the refreshed token should be in the post data for this url

--- a/frontend/src/stores/AuthStore.js
+++ b/frontend/src/stores/AuthStore.js
@@ -30,8 +30,8 @@ export class AuthStore {
   }
   @action
   logout() {
-    localStorage.removeItem("JWT_ACCESS")
-    localStorage.removeItem("JWT_REFRESH")
+    document.cookie = "JWT_ACCESS=; expires=Thu, 01 Jan 1970 00:00:01 GMT;"
+    document.cookie = "JWT_REFRESH=; expires=Thu, 01 Jan 1970 00:00:01 GMT;"
     this.isAuthenticated = false
     this.username = null
     this.email = null


### PR DESCRIPTION
#314 This addresses storing JWT in cookies rather than local storage. As far as CORS is concerned I did not see any code specifically enabling CORs in the project. The CORs header that may have been referenced is coming from the parcel bundler serving assets for dev. This would not be used in a production environment. 

relevant parcel code https://github.com/parcel-bundler/parcel/blob/v2/packages/core/parcel-bundler/src/Server.js#L23-L33