### PR TITLE
enhance front end visit router to check params for particpant id

### DIFF
--- a/frontend/src/components/ParticipantTableComponent/PrevPointTableBody.js
+++ b/frontend/src/components/ParticipantTableComponent/PrevPointTableBody.js
@@ -57,6 +57,7 @@ const PrevPointTableBody = props => {
                     year: "numeric",
                     month: "2-digit",
                     day: "2-digit",
+                    timeZone: "UTC", //the the database's Datefield is not timezone aware, so without the localestring assumes UTC. this was causing an off by one error
                   }
                 )}
               </PrevPointCopy>
@@ -67,7 +68,7 @@ const PrevPointTableBody = props => {
             <TableCell aria-label="tcell">
               {props.sidebarView === SEARCH && (
                 <Link
-                  to="/existingParticipant/visits"
+                  to="/participants/visits"
                   onClick={() => props.handleClick(participant)}
                 >
                   <Fab color="primary" size="small" aria-label="add">

--- a/frontend/src/components/ParticipantTableComponent/PrevPointTableBody.js
+++ b/frontend/src/components/ParticipantTableComponent/PrevPointTableBody.js
@@ -68,7 +68,7 @@ const PrevPointTableBody = props => {
             <TableCell aria-label="tcell">
               {props.sidebarView === SEARCH && (
                 <Link
-                  to="/participants/visits"
+                  to={`/participants/${participant.id}/visits`}
                   onClick={() => props.handleClick(participant)}
                 >
                   <Fab color="primary" size="small" aria-label="add">

--- a/frontend/src/components/QueueComponent/QueueTable/QueueTable.js
+++ b/frontend/src/components/QueueComponent/QueueTable/QueueTable.js
@@ -125,7 +125,7 @@ const QueueTable = observer(({ queueData }) => {
                 notes: rowData.notes ? rowData.notes : "",
                 urgency: rowData.urgency,
               })
-              history.push("/existingParticipant")
+              history.push(`/participants/${rowData.id}`)
             },
           },
         ]}

--- a/frontend/src/components/VisitRouter/VisitData.js
+++ b/frontend/src/components/VisitRouter/VisitData.js
@@ -13,7 +13,7 @@ if the project is improved, this view would become more complex
 import React from "react"
 import Grid from "@material-ui/core/Grid"
 import Container from "@material-ui/core/Container"
-import { PrevPointCopy } from "../Typography"
+import { PrevPointCopy, PrevPointHeading } from "../Typography"
 import { makeStyles } from "@material-ui/core"
 
 const VisitData = () => {
@@ -30,10 +30,13 @@ const VisitData = () => {
     <Container maxWidth="md">
       <Grid container>
         <Grid item xs={12}>
-          <PrevPointCopy className={classes.tempPadding}>
-            Will display the information about one visit including the sep data.
-            high permissions
-          </PrevPointCopy>
+          <div className={classes.tempPadding}>
+            <PrevPointHeading>Visit Data</PrevPointHeading>
+            <PrevPointCopy>
+              Will display the information about one visit including the sep
+              data. high permissions
+            </PrevPointCopy>
+          </div>
         </Grid>
       </Grid>
     </Container>

--- a/frontend/src/components/VisitRouter/VisitData.js
+++ b/frontend/src/components/VisitRouter/VisitData.js
@@ -4,31 +4,35 @@ here you can see all the data from the visit and
 fill out forms. this will have user based permissions on
 the backend ( for third party health providers )
 
+right now, we only care about displaying the sepData, so this can become more
+of a 'hard coded' display of data
 
-
-the api route would be
-'api/visit/:visit_id/populated/'
-
-the front end route may also benefit from id based path
-thus being '/existingParticipant/:participant_id/visits/:visit_id/'
-
-This Component is not very well defined yet, and could be come to different routes, such as:
-'/existingParticipant/:participant_id/visits/:visit_id/forms'
-'/existingParticipant/:participant_id/visits/:visit_id/data'
+if the project is improved, this view would become more complex
 */
 
 import React from "react"
 import Grid from "@material-ui/core/Grid"
 import Container from "@material-ui/core/Container"
 import { PrevPointCopy } from "../Typography"
+import { makeStyles } from "@material-ui/core"
 
 const VisitData = () => {
+  const useStyles = makeStyles({
+    tempPadding: {
+      paddingTop: 100,
+      paddingBottom: 100,
+    },
+  })
+
+  const classes = useStyles()
+
   return (
     <Container maxWidth="md">
       <Grid container>
         <Grid item xs={12}>
-          <PrevPointCopy>
-            secret visit data and/or a form would go here
+          <PrevPointCopy className={classes.tempPadding}>
+            Will display the information about one visit including the sep data.
+            high permissions
           </PrevPointCopy>
         </Grid>
       </Grid>

--- a/frontend/src/components/VisitRouter/VisitTable.js
+++ b/frontend/src/components/VisitRouter/VisitTable.js
@@ -1,32 +1,65 @@
-/*
-a table that shows a row with each visit on it goes here
-it will only show the db visit table info ,
-(SELECT * FROM VISITS WHERE partipant_id = id;)
-the route being
-'api/participants/:participant_id/visits/'
-*/
 import React from "react"
-import { Link } from "react-router-dom"
+import { Link, useParams } from "react-router-dom"
 import Grid from "@material-ui/core/Grid"
 import Container from "@material-ui/core/Container"
-import { PrevPointCopy } from "../Typography"
+import { PrevPointHeading } from "../Typography"
 import PrevPointButton from "../PrevPointButton"
+import PrevPointTableHead from "../ParticipantTableComponent/PrevPointTableHead"
+import { TableBody, TableCell, TableRow, Table } from "@material-ui/core"
+import PropTypes from "prop-types"
 
-const VisitTable = (/** current participants visits*/) => {
+const VisitTable = ({ fullName /** current participants visits*/ }) => {
+  const { participantId } = useParams()
+
+  const mockHeaderTitles = [
+    { title: "will be", mobile: true },
+    { title: "for visits", mobile: true },
+    { title: "relating to", mobile: true },
+    { title: "a participant", mobile: true },
+  ]
+
   return (
     <Container maxWidth="md">
       <Grid container>
         <Grid item xs={12}>
-          <PrevPointCopy>
-            A table listing all the visits for a participant
-          </PrevPointCopy>
-          <PrevPointButton component={Link} to="/existingParticipant/visitData">
-            See a visit
-          </PrevPointButton>
+          <div>
+            <PrevPointHeading>
+              {`${fullName}'s previous visits`}
+            </PrevPointHeading>
+          </div>
+          <Table>
+            <PrevPointTableHead headerTitles={mockHeaderTitles} />
+            <TableBody>
+              <TableRow>
+                <TableCell>Lorem</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Lorem</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Lorem</TableCell>
+              </TableRow>
+              <TableRow>
+                <TableCell>Lorem</TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+          <div>
+            <PrevPointButton
+              component={Link}
+              to={`/participants/${participantId}/visits/visitId`}
+            >
+              each row would have this button
+            </PrevPointButton>
+          </div>
         </Grid>
       </Grid>
     </Container>
   )
+}
+
+VisitTable.propTypes = {
+  fullName: PropTypes.string,
 }
 
 export default VisitTable

--- a/frontend/src/components/VisitRouter/VisitTable.js
+++ b/frontend/src/components/VisitRouter/VisitTable.js
@@ -27,7 +27,7 @@ const VisitTable = ({ fullName /** current participants visits*/ }) => {
               {`${fullName}'s previous visits`}
             </PrevPointHeading>
           </div>
-          <Table>
+          <Table aria-label="visits table">
             <PrevPointTableHead headerTitles={mockHeaderTitles} />
             <TableBody>
               <TableRow>

--- a/frontend/src/components/VisitRouter/index.js
+++ b/frontend/src/components/VisitRouter/index.js
@@ -1,8 +1,5 @@
-/* eslint-disable no-console */
 /*
-// it might be easier to maintain state integrity if we put the participant id in the route
-// '/existingParticipant/:participantId/*'
-
+future:
 we will have to differentiate
 navigating a single visit's medical visitData,
 and editing the top level visit info.
@@ -32,6 +29,7 @@ const VisitRouter = observer(() => {
   const existingVisit = toJS(participantStore.visit)
   const programList = toJS(participantStore.programs)
   const serviceList = toJS(participantStore.services)
+  const fullName = `${participantStore.participant.first_name} ${participantStore.participant.last_name}`
 
   useEffect(() => {
     // kick off api call for program list from Mobx
@@ -79,7 +77,7 @@ const VisitRouter = observer(() => {
 
   return (
     <Switch>
-      <Route exact path="/existingParticipant">
+      <Route exact path="/participants/:participantId">
         {Object.keys(participantStore.visit).length ? (
           <WithSubmit
             component={VisitForm}
@@ -94,10 +92,12 @@ const VisitRouter = observer(() => {
           />
         ) : null}
       </Route>
-      <Route exact path="/existingParticipant/visits" component={VisitTable} />
+      <Route exact path="/participants/:participantId/visits">
+        <VisitTable fullName={fullName} />
+      </Route>
       <Route
         exact
-        path="/existingParticipant/visitData"
+        path="/participants/:participantId/visits/:visitId"
         component={VisitData}
       />
     </Switch>

--- a/frontend/src/routes/index.js
+++ b/frontend/src/routes/index.js
@@ -17,7 +17,7 @@ const Routes = () => {
         <PrivateRoute exact path="/" component={AllQueues} />
         <PrivateRoute exact path="/participants" component={ParticipantList} />
         <PrivateRoute
-          path="/existingParticipant"
+          path="/participants/:participantId"
           component={ExistingParticipantView}
         />
         <PrivateRoute

--- a/frontend/src/stores/ParticipantStore.js
+++ b/frontend/src/stores/ParticipantStore.js
@@ -204,20 +204,22 @@ export class ParticipantStore {
       })
     }
   })
-  getParticipant = flow(function*() {
+  getParticipant = flow(function*(participantId) {
     try {
-      const { ok, data, status } = yield api.getParticipantById(
-        toJS(this.participant.id)
-      )
+      const { ok, data, status } = yield api.getParticipantById(participantId)
       if (!ok || !data) {
         throw new Error(status)
       }
       this.setParticipant(data)
+      // for redirect in exiting participant V
+      return ok
     } catch (error) {
       const snackbarError = handleSnackbarError(error.message)
       this.rootStore.UtilityStore.setSnackbarState(snackbarError.message, {
         severity: snackbarError.severity,
       })
+
+      return false
     }
   })
   // called on  =>  ParticipantList.js

--- a/frontend/src/views/ExistingParticipantView.js
+++ b/frontend/src/views/ExistingParticipantView.js
@@ -53,7 +53,7 @@ const ExistingParticipantView = observer(() => {
     participantStore.getInsurers()
     participantStore.getPrograms()
     async function matchParticpantIdToParams() {
-      if (!participantStore.participant.id !== participantId) {
+      if (participantStore.participant.id !== parseInt(participantId, 10)) {
         // get participant data via param id if not in state or mismatch between state and route
         const ok = await participantStore.getParticipant(participantId)
         if (!ok) {

--- a/frontend/src/views/ExistingParticipantView.js
+++ b/frontend/src/views/ExistingParticipantView.js
@@ -1,7 +1,7 @@
 import React, { useContext, useEffect } from "react"
 import { toJS } from "mobx"
 import { observer } from "mobx-react-lite"
-import { useHistory, Link } from "react-router-dom"
+import { useHistory, Link, useParams } from "react-router-dom"
 import { makeStyles } from "@material-ui/styles"
 import Grid from "@material-ui/core/Grid"
 import Container from "@material-ui/core/Container"
@@ -41,25 +41,30 @@ const ExistingParticipantView = observer(() => {
   const participantStore = rootStore.ParticipantStore
   // Utility store derived from root store
   const utilityStore = rootStore.UtilityStore
-  // set up history for routing pushes
+
+  const { participantId } = useParams()
   const history = useHistory()
 
   const existingParticipant = toJS(participantStore.participant)
   const insurers = toJS(participantStore.insurers)
 
   useEffect(() => {
-    // kick off api calls for insurance list from Mobx
+    // kick off api calls for relevant data
     participantStore.getInsurers()
-    // kick off api calls for program list from Mobx
     participantStore.getPrograms()
-    // -----------------------------------
-
-    // return to /participants page if current participant is not verified with an id
-    // add participants in NewParticipantView
-    if (!participantStore.participant.id) {
-      // todo: reset to empty  object?
-      history.push("/participants")
+    async function matchParticpantIdToParams() {
+      if (!participantStore.participant.id !== participantId) {
+        // get participant data via param id if not in state or mismatch between state and route
+        const ok = await participantStore.getParticipant(participantId)
+        if (!ok) {
+          participantStore.setDefaultParticipant()
+          participantStore.setDefaultVisit()
+          history.push("/404/")
+        }
+      }
     }
+
+    matchParticpantIdToParams()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
@@ -95,10 +100,15 @@ const ExistingParticipantView = observer(() => {
   const handleCancelEditParticipant = () => {
     if (participantStore.isEditing) {
       participantStore.setIsEditing(false)
-      participantStore.getParticipant()
+      participantStore.getParticipant(participantId)
     } else {
       participantStore.setIsEditing(true)
     }
+  }
+
+  //  this logic should be replaced by a loading component
+  if (!existingParticipant.id) {
+    return null
   }
 
   return (
@@ -137,12 +147,18 @@ const ExistingParticipantView = observer(() => {
         </Grid>
         <Grid container spacing={2} className={classes.TempNav}>
           <Grid item xs={12} sm={6} className={classes.ButtonCenter}>
-            <PrevPointButton component={Link} to="/existingParticipant">
+            <PrevPointButton
+              component={Link}
+              to={`/participants/${existingParticipant.id}`}
+            >
               Visit Form
             </PrevPointButton>
           </Grid>
           <Grid item xs={12} sm={6} className={classes.ButtonCenter}>
-            <PrevPointButton component={Link} to="/existingParticipant/visits">
+            <PrevPointButton
+              component={Link}
+              to={`/participants/${existingParticipant.id}/visits`}
+            >
               All Visits Table
             </PrevPointButton>
           </Grid>

--- a/frontend/test/ExistingParticipantView.test.js
+++ b/frontend/test/ExistingParticipantView.test.js
@@ -50,6 +50,16 @@ describe("<ExistingParticipantView /> router basics", () => {
       mockRootStore,
       { route: "/participants/6/" }
     )
+
+    const fname = getByLabelText(/first name/i)
+    const lname = getByLabelText(/last name/i)
+    expect(fname.value).toEqual(
+      mockRootStore.ParticipantStore.participant.first_name
+    )
+    expect(lname.value).toEqual(
+      mockRootStore.ParticipantStore.participant.last_name
+    )
+
     expect(getByLabelText("Participant Form")).toBeInTheDocument()
   })
 
@@ -157,5 +167,45 @@ describe("<ExistingParticipantView /> mounting process", () => {
     expect(notFound).toBeInTheDocument()
 
     expect(history.location.pathname).toEqual("/404/")
+  })
+
+  it("updates the participant to match the url id", async () => {
+    const mockServerResponse = {
+      ok: true,
+      data: {
+        id: 1,
+        pp_id: "GFDRT",
+        sep_id: 10000,
+        first_name: "Jesse",
+        last_name: "Owens",
+        last_four_ssn: "7241",
+        race: "Black (African American)",
+        gender: "m",
+        date_of_birth: "1917-05-31",
+        start_date: "1989-12-05",
+        is_insured: false,
+        insurer: 2,
+        maiden_name: "Rodriguez",
+      },
+    }
+
+    api.getParticipantById = jest.fn().mockResolvedValue(mockServerResponse)
+    const history = createMemoryHistory()
+    history.push("/participants/1/")
+
+    const { findByLabelText } = render(
+      StateAndRouterProviders({
+        children: <ExistingParticipantView />,
+        state: mockRootStore,
+        history,
+      })
+    )
+
+    const fname = await findByLabelText(/first name/i)
+    const lname = await findByLabelText(/last name/i)
+    expect(fname.value).toEqual(mockServerResponse.data.first_name)
+    expect(lname.value).toEqual(mockServerResponse.data.last_name)
+
+    expect(history.location.pathname).toEqual("/participants/1/")
   })
 })

--- a/frontend/test/PrevPointTableBody.test.js
+++ b/frontend/test/PrevPointTableBody.test.js
@@ -44,7 +44,10 @@ describe("<PrevPointTableBody />", () => {
     render(
       <BrowserRouter>
         <PrevPointTableBody participants={mockParticipantsList} />
-      </BrowserRouter>
+      </BrowserRouter>,
+      {
+        container: document.body.appendChild(table),
+      }
     )
   })
 
@@ -53,7 +56,10 @@ describe("<PrevPointTableBody />", () => {
     const { getByText } = render(
       <BrowserRouter>
         <PrevPointTableBody participants={[]} />
-      </BrowserRouter>
+      </BrowserRouter>,
+      {
+        container: document.body.appendChild(table),
+      }
     )
     const tableBodyError = getByText(errorMessage)
     expect(tableBodyError).toBeInTheDocument()

--- a/frontend/test/PrevPointTableHead.test.js
+++ b/frontend/test/PrevPointTableHead.test.js
@@ -9,11 +9,13 @@ const tableContainer = {
 
 describe("<PrevPointTableHead />", () => {
   it("should render a PrevPointTableHead component", () => {
-    render(<PrevPointTableHead />)
+    render(<PrevPointTableHead />, tableContainer)
   })
 
   it("should render a PrevPointTableHead and have a TableHead element", () => {
-    const { getByLabelText } = render(<PrevPointTableHead />, tableContainer)
+    const { getByLabelText } = render(<PrevPointTableHead />, {
+      container: document.body.appendChild(table),
+    })
     const tableHeadElement = getByLabelText(/thead/i)
     expect(tableHeadElement).toBeInTheDocument()
   })


### PR DESCRIPTION
This makes the  existing participant path a little more resilient, and can handle a a refresh without redirecting away from the path.

This adds the participant id, and visit id, into the front end paths.

I also changed the path from `/existingParticipant/` to `/participants/:participantId/` to be more RESTful

#443 

The visitTable changes are just Lorem Ipsum filler, the big changes are the router paths