### PR TITLE
Add filtering by visit_id to sep data endpoint

### DIFF
--- a/core/sep_data/views.py
+++ b/core/sep_data/views.py
@@ -3,5 +3,11 @@ from core.models import SepData
 from core.sep_data.serializers import SepDataSerializer
 
 class Sep_DataViewSet(ModelViewSet):
-    queryset = SepData.objects.all()
     serializer_class = SepDataSerializer
+
+    def get_queryset(self):
+        visit_id = self.request.query_params.get('visit_id', None)
+        queryset = SepData.objects.all()
+        if visit_id is not None:
+            queryset = queryset.filter(visit_id=visit_id)
+        return queryset

--- a/core/tests/sep_data.py
+++ b/core/tests/sep_data.py
@@ -90,3 +90,23 @@ class Sep_DataTestCase(BaseTestCase):
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
         self.assertEqual(pre_post_entry_count, SepData.objects.count())
 
+    def test_filter_by_visit(self):
+        """
+        Test SepData objects can be filtered by visit_id using a query parameter.
+        """
+        # visit id that is present in sep_data.yaml fixture
+        visit_id = 2
+        headers = self.auth_headers_for_user('admin')
+        url = reverse('sepdata-list')
+
+        expected_ids = SepData.objects.filter(
+            visit_id=visit_id
+        ).values_list('id', flat=True)
+        response = self.client.get(url, data={'visit_id': visit_id}, format='json', follow=True, **headers)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(expected_ids), len(response.data))
+
+        expected_ids = set(expected_ids)
+        actual_ids = set(actual_object['id'] for actual_object in response.data)
+        self.assertEqual(expected_ids, actual_ids)

--- a/core/urls.py
+++ b/core/urls.py
@@ -47,7 +47,7 @@ router.register(r"programs", programs_views.ProgramViewSet)
 router.register(r"services", services_views.ServiceViewSet)
 router.register(r"insurers", insurer_views.InsurerViewSet)
 router.register(r"sites", site_views.SiteViewSet)
-router.register(r"sep", sep_data_views.Sep_DataViewSet)
+router.register(r"sep", sep_data_views.Sep_DataViewSet, basename='sepdata')
 
 
 schema_view = get_swagger_view(title="PreventionPoint API")


### PR DESCRIPTION
I modeled this off the Participant viewset, let me know if that's not what you had in mind. Also I called the query parameter `visit_id` to make it more clear to the front-end, but let me know if you think `visit` is better.

Issue #451 mentioned permissions, but it looks like they are already set correctly in users_and_groups.py