### PR TITLE
Insurer field bug

### DIFF
--- a/frontend/src/stores/ParticipantStore.js
+++ b/frontend/src/stores/ParticipantStore.js
@@ -105,11 +105,14 @@ export class ParticipantStore {
       case "is_insured":
         this.participant.is_insured = value === "true"
         if (!this.participant.is_insured) {
-          this.participant.insurer = ""
+          this.participant.insurer = " "
         }
         break
       case "pp_id":
         this.setPPId(value)
+        break
+      case "insurer":
+        this.setInsurer(value)
         break
       default:
         this.participant[name] = value
@@ -128,6 +131,10 @@ export class ParticipantStore {
     const serviceListing = this.programs.find(program => program.id === data)
     this.visit.program = data
     this.setServiceList(serviceListing.services)
+  }
+
+  @action setInsurer = data => {
+    this.participant.insurer = data.toString()
   }
 
   @action handleVisitChange = ({ name, value }) => {

--- a/frontend/src/stores/ParticipantStore.js
+++ b/frontend/src/stores/ParticipantStore.js
@@ -105,7 +105,7 @@ export class ParticipantStore {
       case "is_insured":
         this.participant.is_insured = value === "true"
         if (!this.participant.is_insured) {
-          this.participant.insurer = " "
+          this.participant.insurer = ""
         }
         break
       case "pp_id":
@@ -355,7 +355,6 @@ export class ParticipantStore {
   // called on  =>  ParticipantInfo.js
   // only update basic facts about the participant
   updateParticipant = flow(function*() {
-    this.rootStore.UtilityStore.setLoadingState(true)
     try {
       const { ok, data, status } = yield api.updateParticipant(
         toJS(this.participant.id),

--- a/frontend/src/validation/index.js
+++ b/frontend/src/validation/index.js
@@ -129,17 +129,19 @@ const participantSchema = Yup.object().shape({
     .notRequired()
     .max(100),
   is_insured: Yup.boolean().required(),
-  insurer: Yup.string().when("is_insured", {
-    is: false,
-    then: Yup.string().notRequired(),
-    otherwise: Yup.number().required(),
-  }),
+  insurer: Yup.string()
+    .required()
+    .when("is_insured", {
+      is: false,
+      then: Yup.string().matches(/^\s$/),
+      otherwise: Yup.string().matches(/^\d+$/),
+    }),
 })
 
 const validateForm = (data, inputSchema) => {
   let errors = []
   let schema
-  if (inputSchema === "VISIT_SCHEMA") {
+  if (inputSchema === VISIT_SCHEMA) {
     schema = visitSchema
   } else {
     schema = participantSchema

--- a/frontend/src/validation/index.js
+++ b/frontend/src/validation/index.js
@@ -130,10 +130,10 @@ const participantSchema = Yup.object().shape({
     .max(100),
   is_insured: Yup.boolean().required(),
   insurer: Yup.string()
-    .required()
+    .notRequired()
     .when("is_insured", {
       is: false,
-      then: Yup.string().matches(/^\s$/),
+      then: Yup.string().matches(/^\d+$/, { excludeEmptyString: true }),
       otherwise: Yup.string().matches(/^\d+$/),
     }),
 })


### PR DESCRIPTION
Insurer field only goes through in Yup if set to notRequired. Validates properly when an insurer is present but does not validate if 'is_insured' is false. Because we're setting the value for insurer in the participantstore to empty string and then converting to null on the backend I think this is ok. But let me know if this gives you the heebie jeebies.

Closes #480 