### PR TITLE
PR463: Front end auth checkup

### DIFF
--- a/frontend/.babelrc
+++ b/frontend/.babelrc
@@ -5,5 +5,6 @@
     ["@babel/plugin-proposal-decorators", { "legacy": true }],
     ["@babel/plugin-proposal-class-properties", { "loose": true }, "classes-alias"],
     ["@babel/plugin-proposal-private-methods", { "loose": true }, "methods-alias"]
-  ]
+  ],
+  "sourceMaps": true
 }

--- a/frontend/src/api/authEndpoints.js
+++ b/frontend/src/api/authEndpoints.js
@@ -1,7 +1,7 @@
 import cookieValue, { setAuthCookie } from "./cookies"
 
 export const createToken = api => async (username, password) => {
-  const response = await api.post("/token/", { username, password })
+  const response = await api.post("/api/token/", { username, password })
   if (response.ok) {
     setAuthCookie("JWT_ACCESS", response.data.access)
     setAuthCookie("JWT_REFRESH", response.data.refresh)
@@ -11,6 +11,6 @@ export const createToken = api => async (username, password) => {
 
 export const verifyToken = api => async () => {
   const accessToken = cookieValue("JWT_ACCESS")
-  const response = await api.post("/token/verify/", { token: accessToken })
+  const response = await api.post("/api/token/verify/", { token: accessToken })
   return response
 }

--- a/frontend/src/api/frontDeskEventEndpoints.js
+++ b/frontend/src/api/frontDeskEventEndpoints.js
@@ -1,8 +1,8 @@
 export const getFrontDeskEvent = api => async id =>
-  await api.get(`/front-desk-events/${id}/`)
+  await api.get(`/api/front-desk-events/${id}/`)
 
 export const postFrontDeskEvent = api => async data =>
-  await api.post("/front-desk-events/", data)
+  await api.post("/api/front-desk-events/", data)
 
 export const patchFrontDeskEvent = api => async (id, data) =>
-  await api.patch(`/front-desk-events/${id}/`, data)
+  await api.patch(`/api/front-desk-events/${id}/`, data)

--- a/frontend/src/api/index.js
+++ b/frontend/src/api/index.js
@@ -24,9 +24,7 @@ import { createSEP, getSepDataByVisitId } from "./sepEndpoints"
 import cookieValue from "./cookies"
 
 const create = () => {
-  const api = apisauce.create({
-    baseURL: "/api",
-  })
+  const api = apisauce.create({})
 
   createAuthRefreshInterceptor(api.axiosInstance, refreshAuthLogic(api))
 

--- a/frontend/src/api/insurersEndpoints.js
+++ b/frontend/src/api/insurersEndpoints.js
@@ -1,1 +1,1 @@
-export const getInsurers = api => async () => await api.get("insurers/")
+export const getInsurers = api => async () => await api.get("/api/insurers/")

--- a/frontend/src/api/participantEndpoints.js
+++ b/frontend/src/api/participantEndpoints.js
@@ -20,7 +20,9 @@ export const getParticipantById = api => async id =>
   await api.get(`/api/participants/${id}/`)
 
 export const getParticipantByName = api => async (firstname, lastname) =>
-  await api.get(`/api/participants/?first_name=${firstname}&last_name=${lastname}`)
+  await api.get(
+    `/api/participants/?first_name=${firstname}&last_name=${lastname}`
+  )
 
 export const getParticipant = api => async id =>
   await api.get(`/api/participants/${id}`)

--- a/frontend/src/api/participantEndpoints.js
+++ b/frontend/src/api/participantEndpoints.js
@@ -12,27 +12,24 @@ const removeEmptyParams = params => {
 export const getParticipants = api => async params => {
   const queryParams = queryString.stringify(removeEmptyParams(params))
   return await api.get(
-    queryParams ? `participants/?${queryParams}` : "participants/"
+    queryParams ? `/api/participants/?${queryParams}` : "/api/participants/"
   )
 }
 
 export const getParticipantById = api => async id =>
-  await api.get(`participants/${id}/`)
+  await api.get(`/api/participants/${id}/`)
 
 export const getParticipantByName = api => async (firstname, lastname) =>
-  await api.get(`participants/?first_name=${firstname}&last_name=${lastname}`)
+  await api.get(`/api/participants/?first_name=${firstname}&last_name=${lastname}`)
 
 export const getParticipant = api => async id =>
-  await api.get(`/participants/${id}`)
+  await api.get(`/api/participants/${id}`)
 
 export const getParticipantVisits = api => async id =>
-  await api.get(`/participants/${id}/visits/`)
+  await api.get(`/api/participants/${id}/visits/`)
 
 export const updateParticipant = api => async (id, body) =>
-  await api.put(`/participants/${id}/`, body)
+  await api.put(`/api/participants/${id}/`, body)
 
 export const createParticipant = api => async body =>
-  await api.post("/participants/", body)
-
-// export const postParticipant = api => async (id, body) =>
-// await api.post(`/participant/${id}`, body)
+  await api.post("/api/participants/", body)

--- a/frontend/src/api/programEndpoints.js
+++ b/frontend/src/api/programEndpoints.js
@@ -1,6 +1,6 @@
-export const getPrograms = api => async () => api.get("programs/")
-export const getProgram = api => async id => api.get(`programs/${id}/`)
+export const getPrograms = api => async () => api.get("/api/programs/")
+export const getProgram = api => async id => api.get(`/api/programs/${id}/`)
 export const patchProgram = api => async (id, body) =>
-  api.patch(`programs/${id}/`, body)
+  api.patch(`/api/programs/${id}/`, body)
 
 document.getElementsByClassName("header")

--- a/frontend/src/api/queueEndpoints.js
+++ b/frontend/src/api/queueEndpoints.js
@@ -1,2 +1,2 @@
 export const getQueue = api => async programId =>
-  await api.get(`programs/${programId}/queue/`)
+  await api.get(`/api/programs/${programId}/queue/`)

--- a/frontend/src/api/refreshAuthLogic.js
+++ b/frontend/src/api/refreshAuthLogic.js
@@ -2,7 +2,7 @@ import cookieValue, { setAuthCookie } from "./cookies"
 
 const refreshAuthLogic = api => async failedRequest => {
   const refreshToken = cookieValue("JWT_REFRESH")
-  const tokenRefreshResponse = await api.post("/token/refresh/", {
+  const tokenRefreshResponse = await api.post("/api/token/refresh/", {
     refresh: refreshToken,
   })
   setAuthCookie("JWT_ACCESS", tokenRefreshResponse.data.access)

--- a/frontend/src/api/sepEndpoints.js
+++ b/frontend/src/api/sepEndpoints.js
@@ -1,3 +1,3 @@
-export const createSEP = api => async body => await api.post("/sep/", body)
+export const createSEP = api => async body => await api.post("/api/sep/", body)
 export const getSepDataByVisitId = api => async visitId =>
-  await api.get(`/sep?visit_id=${visitId}`)
+  await api.get(`/api/sep?visit_id=${visitId}`)

--- a/frontend/src/api/siteEndpoints.js
+++ b/frontend/src/api/siteEndpoints.js
@@ -1,2 +1,3 @@
 export const getSites = api => async () => await api.get("/api/sites/")
-export const getSite = api => async siteId => await api.get(`/api/sites/${siteId}`)
+export const getSite = api => async siteId =>
+  await api.get(`/api/sites/${siteId}`)

--- a/frontend/src/api/siteEndpoints.js
+++ b/frontend/src/api/siteEndpoints.js
@@ -1,2 +1,2 @@
-export const getSites = api => async () => await api.get("sites/")
-export const getSite = api => async siteId => await api.get(`sites/${siteId}`)
+export const getSites = api => async () => await api.get("/api/sites/")
+export const getSite = api => async siteId => await api.get(`/api/sites/${siteId}`)

--- a/frontend/src/api/visitEndpoints.js
+++ b/frontend/src/api/visitEndpoints.js
@@ -1,12 +1,12 @@
 // "visits": "http://localhost:8000/api/visits/",
 
-export const getVisits = api => async () => await api.get("visits/")
+export const getVisits = api => async () => await api.get("/api/visits/")
 
 export const updateVisits = api => async (id, body) =>
-  await api.put(`/visits/${id}/`, body)
+  await api.put(`/api/visits/${id}/`, body)
 
 export const createVisits = api => async body =>
-  await api.post("/visits/", body)
+  await api.post("/api/visits/", body)
 
 export const patchVisit = api => async (visitId, data) =>
-  await api.patch(`visits/${visitId}/`, data)
+  await api.patch(`/api/visits/${visitId}/`, data)

--- a/frontend/src/components/SepForm.js
+++ b/frontend/src/components/SepForm.js
@@ -71,7 +71,7 @@ const SepForm = ({
 
   useEffect(() => {
     return handleClear
-  }, [])
+  })
 
   useEffect(() => {
     participantStore.getSites()


### PR DESCRIPTION
1. Hard coding "/api/" prefix to ALL api calls to fix scenarios in which "/api/" wasn't getting prefixed via apisauce object.
2. Adding sourceMaps for easier debugging